### PR TITLE
docs: fix simple typo, priorty -> priority

### DIFF
--- a/StartUp/core_cm3.h
+++ b/StartUp/core_cm3.h
@@ -1474,7 +1474,7 @@ static __INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk);             /* clear bits to change               */
   reg_value  =  (reg_value                       |
                 (0x5FA << SCB_AIRCR_VECTKEY_Pos) | 
-                (PriorityGroupTmp << 8));                                     /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8));                                     /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 


### PR DESCRIPTION
There is a small typo in StartUp/core_cm3.h.

Should read `priority` rather than `priorty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md